### PR TITLE
Fix: Change workflow name on workflow_run to Build and Publish to Dockerhub

### DIFF
--- a/.github/workflows/build-publish-dockerhub.yml
+++ b/.github/workflows/build-publish-dockerhub.yml
@@ -1,4 +1,4 @@
-name: Publish to Dockerhub
+name: Build and Publish to Dockerhub
 
 on:
   release:

--- a/.github/workflows/deploy-aws-ecs.yml
+++ b/.github/workflows/deploy-aws-ecs.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS EC2
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build and Publish to Dockerhub]
     types: [completed]
 
 env:


### PR DESCRIPTION
## [Fix] Change workflow name on workflow_run to Build and Publish to Dockerhub

**🚨 Before submitting, please ensure the following:**

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] New and existing unit tests pass locally with my changes.

---

### What does this PR do?

It fixes the workflow name on workflow_run

### How to test it?

Create a new release